### PR TITLE
Embed existing file out of paths supplied

### DIFF
--- a/Data/FileEmbed.hs
+++ b/Data/FileEmbed.hs
@@ -18,7 +18,7 @@
 module Data.FileEmbed
     ( -- * Embed at compile time
       embedFile
-    , embedFile'
+    , embedOneFileOf
     , embedDir
     , getDir
       -- * Inject into an executable
@@ -76,8 +76,8 @@ embedFile fp =
 -- >
 -- > myFile :: Data.ByteString.ByteString
 -- > myFile = $(embedFile' [ "dirName/fileName", "src/dirName/fileName" ])
-embedFile' :: [FilePath] -> Q Exp
-embedFile' ps =
+embedOneFileOf :: [FilePath] -> Q Exp
+embedOneFileOf ps =
   (runIO $ readExistingFile ps) >>= \ ( path, content ) -> do
 #if MIN_VERSION_template_haskell(2,7,0)
     qAddDependentFile path


### PR DESCRIPTION
Hello Michael,

Please review the change. I'm not sure if you accept any changes into file-embed package...
But just in case you will find it useful, here is what I did: I introduced another embedFile' function that accepts list of paths out of which first existing path will be used to embed file as a resource.

This task arose from the fact that I use Haskell projects with cabal file and from src/ folder in GHCi. Thus, relative paths to my resources are normally working either when compiling with cabal or when working with GHCi, but not both. So, with this change I could make it working for both ways by doing something like this:

resource :: String
resource = decode $ B.unpack $( embedFile' [ "src/resources/file.txt", "resources/file.txt" ] )

Thanks in advance,
Roman Kuznetsov
