### PR TITLE
Enable tests on ghc 6.12.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,21 +33,13 @@ install:
  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - travis_retry cabal update
  - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
- - if [ $GHCVER = "6.12.3" ]; then
-   cabal install --only-dependencies;
-   else
-   cabal install --only-dependencies --enable-tests --enable-benchmarks;
-   fi
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks;
 
 script:
  - if [ -f configure.ac ]; then autoreconf -i; fi
- - if [ $GHCVER = "6.12.3" ]; then
-   cabal configure -v2;
-   else
-   cabal configure --enable-tests --enable-benchmarks -v2;
-   fi
+ - cabal configure --enable-tests --enable-benchmarks -v2;
  - cabal build # this builds all libraries and executables (including tests/benchmarks)
- - if [ $GHCVER != "6.12.3" ]; then cabal test; fi
+ - cabal test
  - cabal check
  - cabal sdist   # tests that a source-distribution can be generated
 

--- a/file-embed.cabal
+++ b/file-embed.cabal
@@ -32,7 +32,6 @@ test-suite test
     hs-source-dirs: test
     build-depends: base
                  , file-embed
-                 , HUnit
                  , filepath
 
 source-repository head

--- a/test/main.hs
+++ b/test/main.hs
@@ -1,9 +1,14 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE OverloadedStrings #-}
 
+import Control.Monad (unless)
 import Data.FileEmbed
-import Test.HUnit ((@?=))
 import System.FilePath ((</>))
+
+infix 1 @?=
+
+(@?=) :: (Eq a, Show a) => a -> a -> IO ()
+actual @?= expected = unless (actual == expected) (error $ "expected: " ++ show expected ++ "\n but got: " ++ show actual)
 
 main :: IO ()
 main = do


### PR DESCRIPTION
Bothered me. We have code for template-haskell <2.5.0, so why not to test it too!