### PR TITLE
Add `embedDirListing`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.0.11
+
+* embedDirListing [#26](https://github.com/snoyberg/file-embed/pull/26)
+
 ## 0.0.10.1
 
 * Minor doc improvements

--- a/Data/FileEmbed.hs
+++ b/Data/FileEmbed.hs
@@ -123,6 +123,8 @@ embedDir fp = do
 --
 -- > myFiles :: [FilePath]
 -- > myFiles = $(embedDirListing "dirName")
+--
+-- @since 0.0.11
 embedDirListing :: FilePath -> Q Exp
 embedDirListing fp = do
     typ <- [t| [FilePath] |]

--- a/Data/FileEmbed.hs
+++ b/Data/FileEmbed.hs
@@ -21,6 +21,7 @@ module Data.FileEmbed
       embedFile
     , embedOneFileOf
     , embedDir
+    , embedDirListing
     , getDir
       -- * Embed as a IsString
     , embedStringFile
@@ -116,6 +117,16 @@ embedDir :: FilePath -> Q Exp
 embedDir fp = do
     typ <- [t| [(FilePath, B.ByteString)] |]
     e <- ListE <$> ((runIO $ fileList fp) >>= mapM (pairToExp fp))
+    return $ SigE e typ
+
+-- | Embed a directory listing recursively in your source code.
+--
+-- > myFiles :: [FilePath]
+-- > myFiles = $(embedDirListing "dirName")
+embedDirListing :: FilePath -> Q Exp
+embedDirListing fp = do
+    typ <- [t| [FilePath] |]
+    e <- ListE <$> ((runIO $ fmap fst <$> fileList fp) >>= mapM strToExp)
     return $ SigE e typ
 
 -- | Get a directory tree in the IO monad.

--- a/file-embed.cabal
+++ b/file-embed.cabal
@@ -1,5 +1,5 @@
 name:            file-embed
-version:         0.0.10.1
+version:         0.0.11
 license:         BSD3
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
Use case: need the file listing to be embedded, but without their contents (which can be huge).