### PR TITLE
Update the license metadata to match the BSD2 license.

### DIFF
--- a/file-embed.cabal
+++ b/file-embed.cabal
@@ -1,6 +1,6 @@
 name:            file-embed
 version:         0.0.14.0
-license:         BSD3
+license:         BSD2
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
 maintainer:      Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
Addresses https://github.com/snoyberg/file-embed/issues/39