### PR TITLE
Add makeRelativeToModule

### DIFF
--- a/Data/FileEmbed.hs
+++ b/Data/FileEmbed.hs
@@ -411,6 +411,11 @@ available, you can use the non-@With@ variants.
 makeRelativeToProject :: FilePath -> Q FilePath
 makeRelativeToProject = makeRelativeToLocationPredicate $ (==) ".cabal" . takeExtension
 
+-- | Take a relative file path and attach it to the directory containing the
+-- current source file.
+makeRelativeToModule :: FilePath -> Q FilePath
+makeRelativeToModule = makeRelativeToLocationPredicate $ const True
+
 -- | Take a predicate to infer the project root and a relative file path, the given file path is then attached to the inferred project root
 --
 -- This function looks at the source location of the Haskell file calling it,


### PR DESCRIPTION
I sometimes like to associate embedded files with the specific modules that import them; this lets me do that a little more easily.