### PR TITLE
Typed file-embed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist
 *.swp
 .stack-work
 /tarballs/
+dist-newstyle

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # ChangeLog for file-embed
 
+## 0.1.0.0
+
+* Add typed variants of all `Data.FileEmbed` functions in `Data.FileEmbed.Typed`
+* Bump minimum `template-haskell` to 2.17.0.0 for typed TH
+* Split out some of the utilities in `Data.FileEmbed` to their own modules
+
 ## 0.0.16.0
 
 * Add `embedFileRelative`

--- a/Data/FileEmbed.hs
+++ b/Data/FileEmbed.hs
@@ -17,6 +17,9 @@
 -- top of your module:
 --
 -- > {-# LANGUAGE TemplateHaskell #-}
+--
+-- We also have @Data.FileEmbed.Typed@ for typed versions of @Q Exp@ functions
+-- in this module.
 module Data.FileEmbed
     ( -- * Embed at compile time
       embedFile

--- a/Data/FileEmbed.hs
+++ b/Data/FileEmbed.hs
@@ -4,15 +4,15 @@
 {-# LANGUAGE RankNTypes #-}
 -- | This module uses template Haskell. Following is a simplified explanation of usage for those unfamiliar with calling Template Haskell functions.
 --
--- The function @embedFile@ in this modules embeds a file into the executable
--- that you can use it at runtime. A file is represented as a @ByteString@.
+-- The function 'embedFile' in this modules embeds a file into the executable
+-- that you can use it at runtime. A file is represented as a 'ByteString'.
 -- However, as you can see below, the type signature indicates a value of type
--- @Q Exp@ will be returned. In order to convert this into a @ByteString@, you
+-- @Q Exp@ will be returned. In order to convert this into a 'ByteString', you
 -- must use Template Haskell syntax, e.g.:
 --
 -- > $(embedFile "myfile.txt")
 --
--- This expression will have type @ByteString@. Be certain to enable the
+-- This expression will have type 'ByteString'. Be certain to enable the
 -- TemplateHaskell language extension, usually by adding the following to the
 -- top of your module:
 --

--- a/Data/FileEmbed.hs
+++ b/Data/FileEmbed.hs
@@ -1,6 +1,7 @@
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE TemplateHaskellQuotes #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE RankNTypes #-}
 -- | This module uses template Haskell. Following is a simplified explanation of usage for those unfamiliar with calling Template Haskell functions.
 --
 -- The function @embedFile@ in this modules embeds a file into the executable
@@ -24,16 +25,13 @@ module Data.FileEmbed
     , embedOneFileOf
     , embedDir
     , embedDirListing
-    , getDir
       -- * Embed as a IsString
     , embedStringFile
     , embedOneStringFileOf
       -- * Inject into an executable
       -- $inject
-#if MIN_VERSION_template_haskell(2,5,0)
     , dummySpace
     , dummySpaceWith
-#endif
     , inject
     , injectFile
     , injectWith
@@ -41,42 +39,20 @@ module Data.FileEmbed
       -- * Relative path manipulation
     , makeRelativeToProject
     , makeRelativeToLocationPredicate
-      -- * Internal
-    , stringToBs
-    , bsToExp
-    , strToExp
     ) where
 
-import Language.Haskell.TH.Syntax
-    ( Exp (AppE, ListE, LitE, TupE, SigE, VarE)
-    , Lit (..)
-    , Q
-    , runIO
-    , qLocation, loc_filename
-#if MIN_VERSION_template_haskell(2,7,0)
-    , Quasi(qAddDependentFile)
-#endif
-    )
-#if MIN_VERSION_template_haskell(2,16,0)
-import Language.Haskell.TH ( mkBytes, bytesPrimL )
-import qualified Data.ByteString.Internal as B
-#endif
-import System.Directory (doesDirectoryExist, doesFileExist,
-                         getDirectoryContents, canonicalizePath)
-import Control.Exception (throw, tryJust, ErrorCall(..))
-import Control.Monad ((<=<), filterM, guard)
-import qualified Data.ByteString as B
-import qualified Data.ByteString.Char8 as B8
-import Control.Arrow ((&&&), second)
-import Control.Applicative ((<$>))
-import Data.ByteString.Unsafe (unsafePackAddressLen)
-import System.IO.Error (isDoesNotExistError)
-import System.IO.Unsafe (unsafePerformIO)
-import System.FilePath ((</>), takeDirectory, takeExtension)
+import qualified Data.FileEmbed.Typed as Typed
+import Language.Haskell.TH (Exp (AppE, VarE), Q, unTypeCode, Code)
+import Data.FileEmbed.Injection
+    ( dummySpace,
+      dummySpaceWith,
+      inject,
+      injectFile,
+      injectWith,
+      injectFileWith )
+import Data.FileEmbed.RelativePath
+    (makeRelativeToProject, makeRelativeToLocationPredicate)
 import Data.String (fromString)
-import Prelude as P
-import Data.List (sortBy)
-import Data.Ord (comparing)
 
 -- | Embed a single file in your source code.
 --
@@ -85,17 +61,13 @@ import Data.Ord (comparing)
 -- > myFile :: Data.ByteString.ByteString
 -- > myFile = $(embedFile "dirName/fileName")
 embedFile :: FilePath -> Q Exp
-embedFile fp =
-#if MIN_VERSION_template_haskell(2,7,0)
-    qAddDependentFile fp >>
-#endif
-  (runIO $ B.readFile fp) >>= bsToExp
+embedFile = unTypeCode . Typed.embedFile
 
 -- | Embed a single file in your source code.
 --   Unlike 'embedFile', path is given relative to project root.
 -- @since 0.0.16.0
 embedFileRelative :: FilePath -> Q Exp
-embedFileRelative = embedFile <=< makeRelativeToProject
+embedFileRelative = unTypeCode . Typed.embedFileRelative
 
 -- | Maybe embed a single file in your source code depending on whether or not file exists.
 --
@@ -110,20 +82,7 @@ embedFileRelative = embedFile <=< makeRelativeToProject
 --
 -- @since 0.0.14.0
 embedFileIfExists :: FilePath -> Q Exp
-embedFileIfExists fp = do
-  mbs <- runIO maybeFile
-  case mbs of
-    Nothing -> [| Nothing |]
-    Just bs -> do
-#if MIN_VERSION_template_haskell(2,7,0)
-      qAddDependentFile fp
-#endif
-      [| Just $(bsToExp bs) |]
-  where
-    maybeFile :: IO (Maybe B.ByteString)
-    maybeFile =
-      either (const Nothing) Just <$>
-      tryJust (guard . isDoesNotExistError) (B.readFile fp)
+embedFileIfExists = unTypeCode . Typed.embedFileIfExists
 
 -- | Embed a single existing file in your source code
 -- out of list a list of paths supplied.
@@ -138,19 +97,7 @@ embedFileIfExists fp = do
 -- > myFile :: Data.ByteString.ByteString
 -- > myFile = $(embedOneFileOf [ "dirName/fileName", "src/dirName/fileName" ])
 embedOneFileOf :: [FilePath] -> Q Exp
-embedOneFileOf ps =
-  (runIO $ readExistingFile ps) >>= \ ( path, content ) -> do
-#if MIN_VERSION_template_haskell(2,7,0)
-    qAddDependentFile path
-#endif
-    bsToExp content
-  where
-    readExistingFile :: [FilePath] -> IO ( FilePath, B.ByteString )
-    readExistingFile xs = do
-      ys <- filterM doesFileExist xs
-      case ys of
-        (p:_) -> B.readFile p >>= \ c -> return ( p, c )
-        _ -> throw $ ErrorCall "Cannot find file to embed as resource"
+embedOneFileOf = unTypeCode . Typed.embedOneFileOf
 
 -- | Embed a directory recursively in your source code.
 --
@@ -164,10 +111,7 @@ embedOneFileOf ps =
 -- > myDir :: [(FilePath, Data.ByteString.ByteString)]
 -- > myDir = $(embedDir "dirName")
 embedDir :: FilePath -> Q Exp
-embedDir fp = do
-    typ <- [t| [(FilePath, B.ByteString)] |]
-    e <- ListE <$> ((runIO $ fileList fp) >>= mapM (pairToExp fp))
-    return $ SigE e typ
+embedDir = unTypeCode . Typed.embedDir
 
 -- | Embed a directory listing recursively in your source code.
 --
@@ -176,53 +120,7 @@ embedDir fp = do
 --
 -- @since 0.0.11
 embedDirListing :: FilePath -> Q Exp
-embedDirListing fp = do
-    typ <- [t| [FilePath] |]
-    e <- ListE <$> ((runIO $ fmap fst <$> fileList fp) >>= mapM strToExp)
-    return $ SigE e typ
-
--- | Get a directory tree in the IO monad.
---
--- This is the workhorse of 'embedDir'
-getDir :: FilePath -> IO [(FilePath, B.ByteString)]
-getDir = fileList
-
-pairToExp :: FilePath -> (FilePath, B.ByteString) -> Q Exp
-pairToExp _root (path, bs) = do
-#if MIN_VERSION_template_haskell(2,7,0)
-    qAddDependentFile $ _root ++ '/' : path
-#endif
-    exp' <- bsToExp bs
-    return $! TupE
-#if MIN_VERSION_template_haskell(2,16,0)
-      $ map Just
-#endif
-      [LitE $ StringL path, exp']
-
-bsToExp :: B.ByteString -> Q Exp
-#if MIN_VERSION_template_haskell(2, 5, 0)
-bsToExp bs =
-    return $ VarE 'unsafePerformIO
-      `AppE` (VarE 'unsafePackAddressLen
-      `AppE` LitE (IntegerL $ fromIntegral $ B8.length bs)
-#if MIN_VERSION_template_haskell(2, 16, 0)
-      `AppE` LitE (bytesPrimL (
-                let B.PS ptr off sz = bs
-                in  mkBytes ptr (fromIntegral off) (fromIntegral sz))))
-#elif MIN_VERSION_template_haskell(2, 8, 0)
-      `AppE` LitE (StringPrimL $ B.unpack bs))
-#else
-      `AppE` LitE (StringPrimL $ B8.unpack bs))
-#endif
-#else
-bsToExp bs = do
-    helper <- [| stringToBs |]
-    let chars = B8.unpack bs
-    return $! AppE helper $! LitE $! StringL chars
-#endif
-
-stringToBs :: String -> B.ByteString
-stringToBs = B8.pack
+embedDirListing = unTypeCode . Typed.embedDirListing
 
 -- | Embed a single file in your source code.
 --
@@ -233,11 +131,7 @@ stringToBs = B8.pack
 --
 -- Since 0.0.9
 embedStringFile :: FilePath -> Q Exp
-embedStringFile fp =
-#if MIN_VERSION_template_haskell(2,7,0)
-    qAddDependentFile fp >>
-#endif
-  (runIO $ P.readFile fp) >>= strToExp
+embedStringFile = stringyAsIsString . Typed.embedStringFile
 
 -- | Embed a single existing string file in your source code
 -- out of list a list of paths supplied.
@@ -249,216 +143,10 @@ embedStringFile fp =
 --
 -- Since 0.0.9
 embedOneStringFileOf :: [FilePath] -> Q Exp
-embedOneStringFileOf ps =
-  (runIO $ readExistingFile ps) >>= \ ( path, content ) -> do
-#if MIN_VERSION_template_haskell(2,7,0)
-    qAddDependentFile path
-#endif
-    strToExp content
-  where
-    readExistingFile :: [FilePath] -> IO ( FilePath, String )
-    readExistingFile xs = do
-      ys <- filterM doesFileExist xs
-      case ys of
-        (p:_) -> P.readFile p >>= \ c -> return ( p, c )
-        _ -> throw $ ErrorCall "Cannot find file to embed as resource"
+embedOneStringFileOf = 
+  stringyAsIsString . Typed.embedOneStringFileOf
 
-strToExp :: String -> Q Exp
-#if MIN_VERSION_template_haskell(2, 5, 0)
-strToExp s =
-    return $ VarE 'fromString
-      `AppE` LitE (StringL s)
-#else
-strToExp s = do
-    helper <- [| fromString |]
-    return $! AppE helper $! LitE $! StringL s
-#endif
-
-notHidden :: FilePath -> Bool
-notHidden ('.':_) = False
-notHidden _ = True
-
-fileList :: FilePath -> IO [(FilePath, B.ByteString)]
-fileList top = fileList' top ""
-
-fileList' :: FilePath -> FilePath -> IO [(FilePath, B.ByteString)]
-fileList' realTop top = do
-    allContents <- filter notHidden <$> getDirectoryContents (realTop </> top)
-    let all' = map ((top </>) &&& (\x -> realTop </> top </> x)) allContents
-    files <- filterM (doesFileExist . snd) all' >>=
-             mapM (liftPair2 . second B.readFile)
-    dirs <- filterM (doesDirectoryExist . snd) all' >>=
-            mapM (fileList' realTop . fst)
-    return $ sortBy (comparing fst) $ concat $ files : dirs
-
-liftPair2 :: Monad m => (a, m b) -> m (a, b)
-liftPair2 (a, b) = b >>= \b' -> return (a, b')
-
-magic :: B.ByteString -> B.ByteString
-magic x = B8.concat ["fe", x]
-
-sizeLen :: Int
-sizeLen = 20
-
-getInner :: B.ByteString -> B.ByteString
-getInner b =
-    let (sizeBS, rest) = B.splitAt sizeLen b
-     in case reads $ B8.unpack sizeBS of
-            (i, _):_ -> B.take i rest
-            [] -> error "Data.FileEmbed (getInner): Your dummy space has been corrupted."
-
-padSize :: Int -> String
-padSize i =
-    let s = show i
-     in replicate (sizeLen - length s) '0' ++ s
-
-#if MIN_VERSION_template_haskell(2,5,0)
--- | Allocate the given number of bytes in the generate executable. That space
--- can be filled up with the 'inject' and 'injectFile' functions.
-dummySpace :: Int -> Q Exp
-dummySpace = dummySpaceWith "MS"
-
--- | Like 'dummySpace', but takes a postfix for the magic string.  In
--- order for this to work, the same postfix must be used by 'inject' /
--- 'injectFile'.  This allows an executable to have multiple
--- 'ByteString's injected into it, without encountering collisions.
---
--- Since 0.0.8
-dummySpaceWith :: B.ByteString -> Int -> Q Exp
-dummySpaceWith postfix space = do
-    let size = padSize space
-        magic' = magic postfix
-        start = B8.unpack magic' ++ size
-        magicLen = B8.length magic'
-        len = magicLen + sizeLen + space
-        chars = LitE $ StringPrimL $
-#if MIN_VERSION_template_haskell(2,6,0)
-            map (toEnum . fromEnum) $
-#endif
-            start ++ replicate space '0'
-    [| getInner (B.drop magicLen (unsafePerformIO (unsafePackAddressLen len $(return chars)))) |]
-#endif
-
--- | Inject some raw data inside a @ByteString@ containing empty, dummy space
--- (allocated with @dummySpace@). Typically, the original @ByteString@ is an
--- executable read from the filesystem.
-inject :: B.ByteString -- ^ bs to inject
-       -> B.ByteString -- ^ original BS containing dummy
-       -> Maybe B.ByteString -- ^ new BS, or Nothing if there is insufficient dummy space
-inject = injectWith "MS"
-
--- | Like 'inject', but takes a postfix for the magic string.
---
--- Since 0.0.8
-injectWith :: B.ByteString -- ^ postfix of magic string
-           -> B.ByteString -- ^ bs to inject
-           -> B.ByteString -- ^ original BS containing dummy
-           -> Maybe B.ByteString -- ^ new BS, or Nothing if there is insufficient dummy space
-injectWith postfix toInj orig =
-    if toInjL > size
-        then Nothing
-        else Just $ B.concat [before, magic', B8.pack $ padSize toInjL, toInj, B8.pack $ replicate (size - toInjL) '0', after]
-  where
-    magic' = magic postfix
-    toInjL = B.length toInj
-    (before, rest) = B.breakSubstring magic' orig
-    (sizeBS, rest') = B.splitAt sizeLen $ B.drop (B8.length magic') rest
-    size = case reads $ B8.unpack sizeBS of
-            (i, _):_ -> i
-            [] -> error $ "Data.FileEmbed (inject): Your dummy space has been corrupted. Size is: " ++ show sizeBS
-    after = B.drop size rest'
-
--- | Same as 'inject', but instead of performing the injecting in memory, read
--- the contents from the filesystem and write back to a different file on the
--- filesystem.
-injectFile :: B.ByteString -- ^ bs to inject
-           -> FilePath -- ^ template file
-           -> FilePath -- ^ output file
-           -> IO ()
-injectFile = injectFileWith "MS"
-
--- | Like 'injectFile', but takes a postfix for the magic string.
---
--- Since 0.0.8
-injectFileWith :: B.ByteString -- ^ postfix of magic string
-               -> B.ByteString -- ^ bs to inject
-               -> FilePath -- ^ template file
-               -> FilePath -- ^ output file
-               -> IO ()
-injectFileWith postfix inj srcFP dstFP = do
-    src <- B.readFile srcFP
-    case injectWith postfix inj src of
-        Nothing -> error "Insufficient dummy space"
-        Just dst -> B.writeFile dstFP dst
-
-{- $inject
-
-The inject system allows arbitrary content to be embedded inside a Haskell
-executable, post compilation. Typically, file-embed allows you to read some
-contents from the file system at compile time and embed them inside your
-executable. Consider a case, instead, where you would want to embed these
-contents after compilation. Two real-world examples are:
-
-* You would like to embed a hash of the executable itself, for sanity checking in a network protocol. (Obviously the hash will change after you embed the hash.)
-
-* You want to create a self-contained web server that has a set of content, but will need to update the content on machines that do not have access to GHC.
-
-The typical workflow use:
-
-* Use 'dummySpace' or 'dummySpaceWith' to create some empty space in your executable
-
-* Use 'injectFile' or 'injectFileWith' from a separate utility to modify that executable to have the updated content.
-
-The reason for the @With@-variant of the functions is for cases where you wish
-to inject multiple different kinds of content, and therefore need control over
-the magic key. If you know for certain that there will only be one dummy space
-available, you can use the non-@With@ variants.
-
--}
-
--- | Take a relative file path and attach it to the root of the current
--- project.
---
--- The idea here is that, when building with Stack, the build will always be
--- executed with a current working directory of the root of the project (where
--- your .cabal file is located). However, if you load up multiple projects with
--- @stack ghci@, the working directory may be something else entirely.
---
--- This function looks at the source location of the Haskell file calling it,
--- finds the first parent directory with a .cabal file, and uses that as the
--- root directory for fixing the relative path.
---
--- @$(makeRelativeToProject "data/foo.txt" >>= embedFile)@
---
--- @since 0.0.10
-makeRelativeToProject :: FilePath -> Q FilePath
-makeRelativeToProject = makeRelativeToLocationPredicate $ (==) ".cabal" . takeExtension
-
--- | Take a predicate to infer the project root and a relative file path, the given file path is then attached to the inferred project root
---
--- This function looks at the source location of the Haskell file calling it,
--- finds the first parent directory with a file matching the given predicate, and uses that as the
--- root directory for fixing the relative path.
---
--- @$(makeRelativeToLocationPredicate ((==) ".cabal" . takeExtension) "data/foo.txt" >>= embedFile)@
---
--- @since 0.0.15.0
-makeRelativeToLocationPredicate :: (FilePath -> Bool) -> FilePath -> Q FilePath
-makeRelativeToLocationPredicate isTargetFile rel = do
-    loc <- qLocation
-    runIO $ do
-        srcFP <- canonicalizePath $ loc_filename loc
-        mdir <- findProjectDir srcFP
-        case mdir of
-            Nothing -> error $ "Could not find .cabal file for path: " ++ srcFP
-            Just dir -> return $ dir </> rel
-  where
-    findProjectDir x = do
-        let dir = takeDirectory x
-        if dir == x
-            then return Nothing
-            else do
-                contents <- getDirectoryContents dir
-                if any isTargetFile contents
-                    then return (Just dir)
-                    else findProjectDir dir
+-- | Constrain the type of the embeded stringy values, and then `fromString` them
+-- again.
+stringyAsIsString :: Code Q String -> Q Exp
+stringyAsIsString s = (VarE 'fromString `AppE`) <$> unTypeCode s

--- a/Data/FileEmbed.hs
+++ b/Data/FileEmbed.hs
@@ -42,6 +42,11 @@ module Data.FileEmbed
       -- * Relative path manipulation
     , makeRelativeToProject
     , makeRelativeToLocationPredicate
+    , getDir
+    -- * Internal
+    , stringToBs
+    , bsToExp
+    , strToExp
     ) where
 
 import qualified Data.FileEmbed.Typed as Typed
@@ -54,8 +59,10 @@ import Data.FileEmbed.Injection
       injectWith,
       injectFileWith )
 import Data.FileEmbed.RelativePath
-    (makeRelativeToProject, makeRelativeToLocationPredicate)
+    (makeRelativeToProject, makeRelativeToLocationPredicate, getDir)
 import Data.String (fromString)
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Char8 as B8
 
 -- | Embed a single file in your source code.
 --
@@ -153,3 +160,17 @@ embedOneStringFileOf =
 -- again.
 stringyAsIsString :: Code Q String -> Q Exp
 stringyAsIsString s = (VarE 'fromString `AppE`) <$> unTypeCode s
+
+{-# WARNING in "x-file-embed-internals" bsToExp "This function is meant for internal `file-embed` use" #-}
+-- | Embed a bytestring into a static string.
+bsToExp :: B.ByteString -> Q Exp
+bsToExp = unTypeCode . Typed.bsToExp
+
+{-# WARNING in "x-file-embed-internals" strToExp "This function is meant for internal `file-embed` use" #-}
+-- | Lifts a stringy value into TH.
+strToExp :: String -> Q Exp
+strToExp = stringyAsIsString . Typed.strToExp
+
+{-# DEPRECATED stringToBs "Use Data.ByteString.Char8.pack instead" #-}
+stringToBs :: String -> B.ByteString
+stringToBs = B8.pack

--- a/Data/FileEmbed/Injection.hs
+++ b/Data/FileEmbed/Injection.hs
@@ -1,0 +1,207 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Data.FileEmbed.Injection
+  ( -- * Inject into an executable
+    -- $inject
+    dummySpace,
+    dummySpaceTyped,
+    dummySpaceWith,
+    dummySpaceWithTyped,
+    inject,
+    injectFile,
+    injectWith,
+    injectFileWith,
+  )
+where
+
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Char8 as B8
+import Data.ByteString.Unsafe (unsafePackAddressLen)
+import GHC.Exts (Addr#)
+import Language.Haskell.TH.Syntax
+  ( Code,
+    Exp (LitE),
+    Lit (..),
+    Q,
+    Quote,
+    unTypeCode,
+    unsafeCodeCoerce,
+  )
+import System.IO.Unsafe (unsafePerformIO)
+import Prelude as P
+
+magic :: B.ByteString -> B.ByteString
+magic x = B8.concat ["fe", x]
+
+sizeLen :: Int
+sizeLen = 20
+
+-- | Snap off the front of the bytestring which contains our magic data, then
+-- take a part of the rest of the bytestring.
+getInner :: B.ByteString -> B.ByteString
+getInner b =
+  let (sizeBS, rest) = B.splitAt sizeLen b
+   in case reads $ B8.unpack sizeBS of
+        (i, _) : _ -> B.take i rest
+        [] -> error "Data.FileEmbed (getInner): Your dummy space has been corrupted."
+
+-- | Show a number and leftpad with 0's.
+padSize :: Int -> String
+padSize i =
+  let s = show i
+   in replicate (sizeLen - length s) '0' ++ s
+
+-- | Allocate the given number of bytes in the generate executable. That space
+-- can be filled up with the 'inject' and 'injectFile' functions.
+--
+-- This version is typed and requires typed template haskell.
+--
+-- @since $ver
+dummySpaceTyped :: (Quote m) => Int -> Code m B.ByteString
+dummySpaceTyped = dummySpaceWithTyped "MS"
+
+-- | Allocate the given number of bytes in the generate executable. That space
+-- can be filled up with the 'inject' and 'injectFile' functions.
+--
+-- @since 0.0.4
+dummySpace :: Int -> Q Exp
+dummySpace = dummySpaceWith "MS"
+
+-- | Like 'dummySpace', but takes a postfix for the magic string.  In
+-- order for this to work, the same postfix must be used by 'inject' /
+-- 'injectFile'.  This allows an executable to have multiple
+-- 'ByteString's injected into it, without encountering collisions.
+--
+-- This version is typed and requires typed template haskell.
+--
+-- @since $ver
+dummySpaceWithTyped :: (Quote m) => B.ByteString -> Int -> Code m B.ByteString
+dummySpaceWithTyped postfix space = do
+  let size = padSize space
+      magic' = magic postfix
+      start = B8.unpack magic' ++ size
+      magicLen = B8.length magic'
+      len = magicLen + sizeLen + space
+      -- can't lift [Word8] into an Addr# directly
+      chars :: (Quote m) => Code m Addr#
+      chars =
+        unsafeCodeCoerce $
+          pure $
+            LitE $
+              StringPrimL $
+                map (toEnum . fromEnum) $
+                  start ++ replicate space '0'
+  [||getInner (B.drop magicLen (unsafePerformIO (unsafePackAddressLen len $$chars)))||]
+
+-- | Like 'dummySpace', but takes a postfix for the magic string.  In
+-- order for this to work, the same postfix must be used by 'inject' /
+-- 'injectFile'.  This allows an executable to have multiple
+-- 'ByteString's injected into it, without encountering collisions.
+--
+-- @since 0.0.8
+dummySpaceWith :: B.ByteString -> Int -> Q Exp
+dummySpaceWith postfix space = unTypeCode $ dummySpaceWithTyped postfix space
+
+-- | Inject some raw data inside a @ByteString@ containing empty, dummy space
+-- (allocated with @dummySpace@). Typically, the original @ByteString@ is an
+-- executable read from the filesystem.
+--
+-- @since 0.0.4
+inject ::
+  -- | bs to inject
+  B.ByteString ->
+  -- | original BS containing dummy
+  B.ByteString ->
+  -- | new BS, or Nothing if there is insufficient dummy space
+  Maybe B.ByteString
+inject = injectWith "MS"
+
+-- | Like 'inject', but takes a postfix for the magic string.
+--
+-- @since 0.0.8
+injectWith ::
+  -- | postfix of magic string
+  B.ByteString ->
+  -- | bs to inject
+  B.ByteString ->
+  -- | original BS containing dummy
+  B.ByteString ->
+  -- | new BS, or Nothing if there is insufficient dummy space
+  Maybe B.ByteString
+injectWith postfix toInj orig =
+  if toInjL > size
+    then Nothing
+    else Just $ B.concat [before, magic', B8.pack $ padSize toInjL, toInj, B8.pack $ replicate (size - toInjL) '0', after]
+  where
+    magic' = magic postfix
+    toInjL = B.length toInj
+    (before, rest) = B.breakSubstring magic' orig
+    (sizeBS, rest') = B.splitAt sizeLen $ B.drop (B8.length magic') rest
+    size = case reads $ B8.unpack sizeBS of
+      (i, _) : _ -> i
+      [] -> error $ "Data.FileEmbed (inject): Your dummy space has been corrupted. Size is: " ++ show sizeBS
+    after = B.drop size rest'
+
+-- | Same as 'inject', but instead of performing the injecting in memory, read
+-- the contents from the filesystem and write back to a different file on the
+-- filesystem.
+--
+-- @since 0.0.4
+injectFile ::
+  -- | bs to inject
+  B.ByteString ->
+  -- | template file
+  FilePath ->
+  -- | output file
+  FilePath ->
+  IO ()
+injectFile = injectFileWith "MS"
+
+-- | Like 'injectFile', but takes a postfix for the magic string.
+--
+-- @since 0.0.8
+injectFileWith ::
+  -- | postfix of magic string
+  B.ByteString ->
+  -- | bs to inject
+  B.ByteString ->
+  -- | template file
+  FilePath ->
+  -- | output file
+  FilePath ->
+  IO ()
+injectFileWith postfix inj srcFP dstFP = do
+  src <- B.readFile srcFP
+  case injectWith postfix inj src of
+    Nothing -> error "Insufficient dummy space"
+    Just dst -> B.writeFile dstFP dst
+
+-- $inject
+--
+-- The inject system allows arbitrary content to be embedded inside a Haskell
+-- executable, post compilation. Typically, file-embed allows you to read some
+-- contents from the file system at compile time and embed them inside your
+-- executable. Consider a case, instead, where you would want to embed these
+-- contents after compilation. Two real-world examples are:
+--
+-- * You would like to embed a hash of the executable itself, for sanity checking in a network protocol. (Obviously the hash will change after you embed the hash.)
+--
+-- * You want to create a self-contained web server that has a set of content, but will need to update the content on machines that do not have access to GHC.
+--
+-- The typical workflow use:
+--
+-- * Use 'dummySpace' or 'dummySpaceWith' to create some empty space in your executable
+--
+-- * Use 'injectFile' or 'injectFileWith' from a separate utility to modify that executable to have the updated content.
+--
+-- The reason for the @With@-variant of the functions is for cases where you wish
+-- to inject multiple different kinds of content, and therefore need control over
+-- the magic key. If you know for certain that there will only be one dummy space
+-- available, you can use the non-@With@ variants.

--- a/Data/FileEmbed/Injection.hs
+++ b/Data/FileEmbed/Injection.hs
@@ -105,7 +105,7 @@ dummySpaceWithTyped postfix space = do
 -- | Like 'dummySpace', but takes a postfix for the magic string.  In
 -- order for this to work, the same postfix must be used by 'inject' /
 -- 'injectFile'.  This allows an executable to have multiple
--- 'B.ByteString's injected into it, without encountering collisions.
+-- 'ByteString' s injected into it, without encountering collisions.
 --
 -- See 'dummySpaceWithTyped' for a typed variant.
 --
@@ -113,8 +113,8 @@ dummySpaceWithTyped postfix space = do
 dummySpaceWith :: B.ByteString -> Int -> Q Exp
 dummySpaceWith postfix space = unTypeCode $ dummySpaceWithTyped postfix space
 
--- | Inject some raw data inside a 'B.ByteString' containing empty, dummy space
--- (allocated with 'dummySpace'). Typically, the original 'B.ByteString' is an
+-- | Inject some raw data inside a 'ByteString' containing empty, dummy space
+-- (allocated with 'dummySpace'). Typically, the original 'ByteString' is an
 -- executable read from the filesystem.
 --
 -- @since 0.0.4

--- a/Data/FileEmbed/Injection.hs
+++ b/Data/FileEmbed/Injection.hs
@@ -63,7 +63,7 @@ padSize i =
 --
 -- This version is typed and requires typed template haskell.
 --
--- @since $ver
+-- @since 0.1.0.0
 dummySpaceTyped :: (Quote m) => Int -> Code m B.ByteString
 dummySpaceTyped = dummySpaceWithTyped "MS"
 
@@ -81,7 +81,7 @@ dummySpace = dummySpaceWith "MS"
 --
 -- This version is typed and requires typed template haskell.
 --
--- @since $ver
+-- @since 0.1.0.0
 dummySpaceWithTyped :: (Quote m) => B.ByteString -> Int -> Code m B.ByteString
 dummySpaceWithTyped postfix space = do
   let size = padSize space

--- a/Data/FileEmbed/Injection.hs
+++ b/Data/FileEmbed/Injection.hs
@@ -61,7 +61,7 @@ padSize i =
 -- | Allocate the given number of bytes in the generate executable. That space
 -- can be filled up with the 'inject' and 'injectFile' functions.
 --
--- See @dummySpace@ for an untyped variant.
+-- See 'dummySpace' for an untyped variant.
 --
 -- @since 0.1.0.0
 dummySpaceTyped :: (Quote m) => Int -> Code m B.ByteString
@@ -70,7 +70,7 @@ dummySpaceTyped = dummySpaceWithTyped "MS"
 -- | Allocate the given number of bytes in the generate executable. That space
 -- can be filled up with the 'inject' and 'injectFile' functions.
 --
--- See @dummySpaceTyped@ for a typed variant.
+-- See 'dummySpaceTyped' for a typed variant.
 --
 -- @since 0.0.4
 dummySpace :: Int -> Q Exp
@@ -81,7 +81,7 @@ dummySpace = dummySpaceWith "MS"
 -- 'injectFile'.  This allows an executable to have multiple
 -- 'ByteString's injected into it, without encountering collisions.
 --
--- See @dummySpaceWith@ for an untyped variant.
+-- See 'dummySpaceWith' for an untyped variant.
 --
 -- @since 0.1.0.0
 dummySpaceWithTyped :: (Quote m) => B.ByteString -> Int -> Code m B.ByteString
@@ -105,16 +105,16 @@ dummySpaceWithTyped postfix space = do
 -- | Like 'dummySpace', but takes a postfix for the magic string.  In
 -- order for this to work, the same postfix must be used by 'inject' /
 -- 'injectFile'.  This allows an executable to have multiple
--- 'ByteString's injected into it, without encountering collisions.
+-- 'B.ByteString's injected into it, without encountering collisions.
 --
--- See @dummySpaceWithTyped@ for a typed variant.
+-- See 'dummySpaceWithTyped' for a typed variant.
 --
 -- @since 0.0.8
 dummySpaceWith :: B.ByteString -> Int -> Q Exp
 dummySpaceWith postfix space = unTypeCode $ dummySpaceWithTyped postfix space
 
--- | Inject some raw data inside a @ByteString@ containing empty, dummy space
--- (allocated with @dummySpace@). Typically, the original @ByteString@ is an
+-- | Inject some raw data inside a 'B.ByteString' containing empty, dummy space
+-- (allocated with 'dummySpace'). Typically, the original 'B.ByteString' is an
 -- executable read from the filesystem.
 --
 -- @since 0.0.4

--- a/Data/FileEmbed/Injection.hs
+++ b/Data/FileEmbed/Injection.hs
@@ -61,7 +61,7 @@ padSize i =
 -- | Allocate the given number of bytes in the generate executable. That space
 -- can be filled up with the 'inject' and 'injectFile' functions.
 --
--- This version is typed and requires typed template haskell.
+-- See @dummySpace@ for an untyped variant.
 --
 -- @since 0.1.0.0
 dummySpaceTyped :: (Quote m) => Int -> Code m B.ByteString
@@ -69,6 +69,8 @@ dummySpaceTyped = dummySpaceWithTyped "MS"
 
 -- | Allocate the given number of bytes in the generate executable. That space
 -- can be filled up with the 'inject' and 'injectFile' functions.
+--
+-- See @dummySpaceTyped@ for a typed variant.
 --
 -- @since 0.0.4
 dummySpace :: Int -> Q Exp
@@ -79,7 +81,7 @@ dummySpace = dummySpaceWith "MS"
 -- 'injectFile'.  This allows an executable to have multiple
 -- 'ByteString's injected into it, without encountering collisions.
 --
--- This version is typed and requires typed template haskell.
+-- See @dummySpaceWith@ for an untyped variant.
 --
 -- @since 0.1.0.0
 dummySpaceWithTyped :: (Quote m) => B.ByteString -> Int -> Code m B.ByteString
@@ -104,6 +106,8 @@ dummySpaceWithTyped postfix space = do
 -- order for this to work, the same postfix must be used by 'inject' /
 -- 'injectFile'.  This allows an executable to have multiple
 -- 'ByteString's injected into it, without encountering collisions.
+--
+-- See @dummySpaceWithTyped@ for a typed variant.
 --
 -- @since 0.0.8
 dummySpaceWith :: B.ByteString -> Int -> Q Exp

--- a/Data/FileEmbed/RelativePath.hs
+++ b/Data/FileEmbed/RelativePath.hs
@@ -3,18 +3,29 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Data.FileEmbed.RelativePath
-  ( -- * Relative path manipulation
-    makeRelativeToProject,
+  ( makeRelativeToProject,
     makeRelativeToLocationPredicate,
+    getDir,
   )
 where
 
+import Control.Arrow ((&&&))
+import Control.Monad (filterM)
+import Data.Bitraversable (bitraverse)
+import qualified Data.ByteString as B
+import Data.List (sortBy)
+import Data.Ord (comparing)
 import Language.Haskell.TH.Syntax
   ( Quasi (..),
     loc_filename,
     qLocation,
   )
-import System.Directory (canonicalizePath, getDirectoryContents)
+import System.Directory
+  ( canonicalizePath,
+    doesDirectoryExist,
+    doesFileExist,
+    getDirectoryContents,
+  )
 import System.FilePath (takeDirectory, takeExtension, (</>))
 import Prelude as P
 
@@ -66,3 +77,29 @@ makeRelativeToLocationPredicate isTargetFile rel = do
           if any isTargetFile contents
             then return (Just dir)
             else findProjectDir dir
+
+-- not the same as the other two functions but gets files relative to a root
+
+-- | Given a root folder, recursively get all files found in all subdirectories.
+-- Sorts by filepath.
+--
+-- Skips "hidden" files; specifically, those with a `.` at the front.
+getDir :: FilePath -> IO [(FilePath, B.ByteString)]
+getDir root = fileList ""
+  where
+    fileList :: FilePath -> IO [(FilePath, B.ByteString)]
+    fileList top = do
+      allContents <- filter notHidden <$> getDirectoryContents (root </> top)
+      let -- relative paths from root and absolute paths from root for each file
+          relAndAbsPaths :: [(FilePath, FilePath)] = map ((top </>) &&& ((root </> top) </>)) allContents
+      files <-
+        filterM (doesFileExist . snd) relAndAbsPaths
+          >>= mapM (bitraverse pure B.readFile)
+      dirs <-
+        filterM (doesDirectoryExist . snd) relAndAbsPaths
+          >>= mapM (fileList . fst)
+      return $ sortBy (comparing fst) $ concat $ files : dirs
+      where
+        notHidden :: FilePath -> Bool
+        notHidden ('.' : _) = False
+        notHidden _ = True

--- a/Data/FileEmbed/RelativePath.hs
+++ b/Data/FileEmbed/RelativePath.hs
@@ -32,7 +32,7 @@ import Prelude as P
 --
 -- @$(makeRelativeToProject "data/foo.txt" >>= embedFile)@
 --
--- @$$(makeRelativeToProject "data/foo.txt" `bindCode` Typed.embedFile)@
+-- @$$(makeRelativeToProject "data/foo.txt" \`bindCode\` Typed.embedFile)@
 --
 -- @since 0.0.10
 makeRelativeToProject :: (Quasi m) => FilePath -> m FilePath

--- a/Data/FileEmbed/RelativePath.hs
+++ b/Data/FileEmbed/RelativePath.hs
@@ -32,6 +32,8 @@ import Prelude as P
 --
 -- @$(makeRelativeToProject "data/foo.txt" >>= embedFile)@
 --
+-- @$$(makeRelativeToProject "data/foo.txt" `bindCode` Typed.embedFile)@
+--
 -- @since 0.0.10
 makeRelativeToProject :: (Quasi m) => FilePath -> m FilePath
 makeRelativeToProject = makeRelativeToLocationPredicate $ (==) ".cabal" . takeExtension

--- a/Data/FileEmbed/RelativePath.hs
+++ b/Data/FileEmbed/RelativePath.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Data.FileEmbed.RelativePath
+  ( -- * Relative path manipulation
+    makeRelativeToProject,
+    makeRelativeToLocationPredicate,
+  )
+where
+
+import Language.Haskell.TH.Syntax
+  ( Quasi (..),
+    loc_filename,
+    qLocation,
+  )
+import System.Directory (canonicalizePath, getDirectoryContents)
+import System.FilePath (takeDirectory, takeExtension, (</>))
+import Prelude as P
+
+-- | Take a relative file path and attach it to the root of the current
+-- project.
+--
+-- The idea here is that, when building with Stack, the build will always be
+-- executed with a current working directory of the root of the project (where
+-- your .cabal file is located). However, if you load up multiple projects with
+-- @stack ghci@, the working directory may be something else entirely.
+--
+-- This function looks at the source location of the Haskell file calling it,
+-- finds the first parent directory with a .cabal file, and uses that as the
+-- root directory for fixing the relative path.
+--
+-- @$(makeRelativeToProject "data/foo.txt" >>= embedFile)@
+--
+-- @since 0.0.10
+makeRelativeToProject :: (Quasi m) => FilePath -> m FilePath
+makeRelativeToProject = makeRelativeToLocationPredicate $ (==) ".cabal" . takeExtension
+
+-- | Take a predicate to infer the project root and a relative file path, the given file path is then attached to the inferred project root
+--
+-- This function looks at the source location of the Haskell file calling it,
+-- finds the first parent directory with a file matching the given predicate, and uses that as the
+-- root directory for fixing the relative path.
+--
+-- @$(makeRelativeToLocationPredicate ((==) ".cabal" . takeExtension) "data/foo.txt" >>= embedFile)@
+--
+-- @since 0.0.15.0
+makeRelativeToLocationPredicate :: (Quasi m) => (FilePath -> Bool) -> FilePath -> m FilePath
+makeRelativeToLocationPredicate isTargetFile rel = do
+  loc <- qLocation
+  qRunIO $ do
+    srcFP <- canonicalizePath $ loc_filename loc
+    mdir <- findProjectDir srcFP
+    case mdir of
+      Nothing -> error $ "Could not find .cabal file for path: " ++ srcFP
+      Just dir -> return $ dir </> rel
+  where
+    findProjectDir x = do
+      let dir = takeDirectory x
+      if dir == x
+        then return Nothing
+        else do
+          contents <- getDirectoryContents dir
+          if any isTargetFile contents
+            then return (Just dir)
+            else findProjectDir dir

--- a/Data/FileEmbed/Typed.hs
+++ b/Data/FileEmbed/Typed.hs
@@ -68,7 +68,7 @@ import Data.FileEmbed.RelativePath (makeRelativeToProject)
 -- > myFile :: Data.ByteString.ByteString
 -- > myFile = $$(embedFile "dirName/fileName")
 --
--- @since $ver
+-- @since 0.1.0.0
 embedFile :: (Quote m, Quasi m) => FilePath -> Code m B.ByteString
 embedFile fp =
     (qAddDependentFile fp >> qRunIO (B.readFile fp)) `bindCode` bsToExp
@@ -76,7 +76,7 @@ embedFile fp =
 -- | Embed a single file in your source code.
 --   Unlike 'embedFile', path is given relative to project root.
 --
--- @since $ver
+-- @since 0.1.0.0
 embedFileRelative :: (Quote m, Quasi m) => FilePath -> Code m B.ByteString
 embedFileRelative fp = makeRelativeToProject fp `bindCode` embedFile
 
@@ -91,7 +91,7 @@ embedFileRelative fp = makeRelativeToProject fp `bindCode` embedFile
 -- > maybeMyFile :: Maybe Data.ByteString.ByteString
 -- > maybeMyFile = $$(embedFileIfExists "dirName/fileName")
 --
--- @since $ver
+-- @since 0.1.0.0
 embedFileIfExists :: (Quote m, Quasi m) => FilePath -> Code m (Maybe B.ByteString)
 embedFileIfExists fp = do
   maybeFile `bindCode` \case
@@ -117,7 +117,7 @@ embedFileIfExists fp = do
 -- > myFile :: Data.ByteString.ByteString
 -- > myFile = $$(embedOneFileOf [ "dirName/fileName", "src/dirName/fileName" ])
 --
--- @since $ver
+-- @since 0.1.0.0
 embedOneFileOf :: (Quote m, Quasi m) => [FilePath] -> Code m B.ByteString
 embedOneFileOf ps =
   readExistingFile B.readFile ps `bindCode` bsToExp
@@ -143,7 +143,7 @@ readExistingFile readFile' xs = do
 -- > myDir :: [(FilePath, Data.ByteString.ByteString)]
 -- > myDir = $$(embedDir "dirName")
 --
--- @since $ver
+-- @since 0.1.0.0
 embedDir :: (Quasi m, Quote m) => FilePath -> Code m [(FilePath, B.ByteString)]
 embedDir fp = do
   qRunIO (fileList fp) `bindCode` (convertList . fmap (pairToExp fp))
@@ -157,7 +157,7 @@ embedDir fp = do
 -- > myFiles :: [FilePath]
 -- > myFiles = $(embedDirListing "dirName")
 --
--- @since $ver
+-- @since 0.1.0.0
 embedDirListing :: (Quote m, Quasi m) => FilePath -> Code m [FilePath]
 embedDirListing fp = do
   qRunIO (fileList fp) `bindCode` (convertList . fmap (strToExp . fst))
@@ -185,7 +185,7 @@ bsToExp bs =
 -- > myFile :: IsString a => a
 -- > myFile = $$(embedStringFile "dirName/fileName")
 --
--- @since $ver
+-- @since 0.1.0.0
 embedStringFile :: (IsString s, Quote m, Quasi m) => FilePath -> Code m s
 embedStringFile fp = (qAddDependentFile fp >> qRunIO (P.readFile fp)) `bindCode` strToExp
 
@@ -197,7 +197,7 @@ embedStringFile fp = (qAddDependentFile fp >> qRunIO (P.readFile fp)) `bindCode`
 -- first such file. You might try to fix this by doing a clean build or using
 -- GHC's -fforce-recomp flag.
 --
--- @since $ver
+-- @since 0.1.0.0
 embedOneStringFileOf :: (IsString s, Quote m, Quasi m) => [FilePath] -> Code m s
 embedOneStringFileOf ps =
   readExistingFile P.readFile ps `bindCode` strToExp

--- a/Data/FileEmbed/Typed.hs
+++ b/Data/FileEmbed/Typed.hs
@@ -1,0 +1,229 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeApplications #-}
+-- | This module uses template Haskell. Following is a simplified explanation of usage for those unfamiliar with calling Template Haskell functions.
+--
+-- The function @embedFile@ in this modules embeds a file into the executable
+-- that you can use it at runtime. A file is represented as a @ByteString@.
+-- However, as you can see below, the type signature indicates a value of type
+-- @Code m ByteString@ will be returned. In order to convert this into a 
+-- @ByteString@, you must use Typed Template Haskell syntax, e.g.:
+--
+-- > $$(embedFile "myfile.txt")
+--
+-- This expression will have type @ByteString@. Be certain to enable the
+-- TemplateHaskell language extension, usually by adding the following to the
+-- top of your module:
+--
+-- > {-# LANGUAGE TemplateHaskell #-}
+--
+-- Note that this module is the typed variant of @Data.FileEmbed@.
+module Data.FileEmbed.Typed
+    ( -- * Embed at compile time
+      embedFile
+    , embedFileRelative
+    , embedFileIfExists
+    , embedOneFileOf
+    , embedDir
+    , embedDirListing
+      -- * Embed as a IsString
+    , embedStringFile
+    , embedOneStringFileOf
+    ) where
+
+import Language.Haskell.TH.Syntax
+    ( Quasi(..), Quote, Code, unsafeCodeCoerce, bindCode, Exp (LitE), bindCode_,
+    )
+import Language.Haskell.TH ( mkBytes, bytesPrimL )
+import qualified Data.ByteString.Internal as B
+import System.Directory (doesDirectoryExist, doesFileExist,
+                         getDirectoryContents)
+import Control.Exception (tryJust)
+import Control.Monad (filterM, guard)
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Char8 as B8
+import Control.Arrow ((&&&))
+import Data.ByteString.Unsafe (unsafePackAddressLen)
+import System.IO.Error (isDoesNotExistError)
+import System.IO.Unsafe (unsafePerformIO)
+import System.FilePath ((</>))
+import Data.String (fromString, IsString)
+import Prelude as P
+import Data.List (sortBy)
+import Data.Ord (comparing)
+import Data.Functor (($>))
+import GHC.Exts (Addr#)
+import Data.Bitraversable (bitraverse)
+import Data.FileEmbed.RelativePath (makeRelativeToProject)
+
+-- | Embed a single file in your source code.
+--
+-- > import qualified Data.ByteString
+-- >
+-- > myFile :: Data.ByteString.ByteString
+-- > myFile = $$(embedFile "dirName/fileName")
+--
+-- @since $ver
+embedFile :: (Quote m, Quasi m) => FilePath -> Code m B.ByteString
+embedFile fp =
+    (qAddDependentFile fp >> qRunIO (B.readFile fp)) `bindCode` bsToExp
+
+-- | Embed a single file in your source code.
+--   Unlike 'embedFile', path is given relative to project root.
+--
+-- @since $ver
+embedFileRelative :: (Quote m, Quasi m) => FilePath -> Code m B.ByteString
+embedFileRelative fp = makeRelativeToProject fp `bindCode` embedFile
+
+-- | Maybe embed a single file in your source code depending on whether or not file exists.
+--
+-- Warning: When a build is compiled with the file missing, a recompile when the
+-- file exists might not trigger an embed of the file. You might try to fix this
+-- by doing a clean build or using GHC's -fforce-recomp flag.
+--
+-- > import qualified Data.ByteString
+-- >
+-- > maybeMyFile :: Maybe Data.ByteString.ByteString
+-- > maybeMyFile = $$(embedFileIfExists "dirName/fileName")
+--
+-- @since $ver
+embedFileIfExists :: (Quote m, Quasi m) => FilePath -> Code m (Maybe B.ByteString)
+embedFileIfExists fp = do
+  maybeFile `bindCode` \case
+    Nothing -> [|| Nothing ||]
+    Just bs -> [|| Just $$(bsToExp bs) ||]
+  where
+    maybeFile :: Quasi m => m (Maybe B.ByteString)
+    maybeFile = do
+      qRunIO (tryJust (guard . isDoesNotExistError) (B.readFile fp)) >>= \case
+        Left _ -> pure Nothing
+        Right bs -> qAddDependentFile fp $> Just bs
+
+-- | Embed a single existing file in your source code
+-- out of list a list of paths supplied.
+--
+-- Warning: When a build is compiled with initial file(s) in the list missing, a
+-- recompile when one of those files exists might not trigger an embed of the
+-- first such file. You might try to fix this by doing a clean build or using
+-- GHC's -fforce-recomp flag.
+--
+-- > import qualified Data.ByteString
+-- >
+-- > myFile :: Data.ByteString.ByteString
+-- > myFile = $$(embedOneFileOf [ "dirName/fileName", "src/dirName/fileName" ])
+--
+-- @since $ver
+embedOneFileOf :: (Quote m, Quasi m) => [FilePath] -> Code m B.ByteString
+embedOneFileOf ps =
+  readExistingFile B.readFile ps `bindCode` bsToExp
+
+-- | Utility function to read a file and add it as a dependent file using the
+-- given file reader.
+readExistingFile :: Quasi m => (FilePath -> IO s) -> [FilePath] -> m s
+readExistingFile readFile' xs = do
+  ys <- qRunIO $ filterM doesFileExist xs
+  case ys of
+    (p:_) -> qRunIO (readFile' p) >>= (qAddDependentFile p $>)
+    _ -> error "Cannot find file to embed as resource"
+
+-- | Embed a directory recursively in your source code.
+--
+-- Warning: When a build is compiled with a file missing from the directory, a
+-- recompile when that file is added might not trigger an embed of the file. You
+-- might try to fix this by doing a clean build or using GHC's -fforce-recomp
+-- flag.
+--
+-- > import qualified Data.ByteString
+-- >
+-- > myDir :: [(FilePath, Data.ByteString.ByteString)]
+-- > myDir = $$(embedDir "dirName")
+--
+-- @since $ver
+embedDir :: (Quasi m, Quote m) => FilePath -> Code m [(FilePath, B.ByteString)]
+embedDir fp = do
+  qRunIO (fileList fp) `bindCode` (convertList . fmap (pairToExp fp))
+  where
+  pairToExp :: forall m . (Quote m, Quasi m) => FilePath -> (FilePath, B.ByteString) -> Code m (FilePath, B.ByteString)
+  pairToExp root (path, bs) = do
+    qAddDependentFile @m (root ++ '/' : path) `bindCode_` let bs' = bsToExp bs in [||(path, $$bs')||]
+
+-- | Embed a directory listing recursively in your source code.
+--
+-- > myFiles :: [FilePath]
+-- > myFiles = $(embedDirListing "dirName")
+--
+-- @since $ver
+embedDirListing :: (Quote m, Quasi m) => FilePath -> Code m [FilePath]
+embedDirListing fp = do
+  qRunIO (fileList fp) `bindCode` (convertList . fmap (strToExp . fst))
+
+-- | Utility to turn a list of Codes into a Code of a list.
+convertList :: (Quote m) => [Code m a] -> Code m [a]
+convertList =
+  foldr (\a z -> [|| $$a : $$z ||]) [|| [] ||]
+
+-- | Embed a bytestring into a static string.
+bsToExp :: Quote m => B.ByteString -> Code m B.ByteString
+bsToExp bs =
+  [|| unsafePerformIO (unsafePackAddressLen (fromIntegral $ B8.length bs) $$addr) ||]
+  where
+  -- can't lift Bytes into an Addr# directly
+  addr :: Quote m => Code m Addr#
+  addr = unsafeCodeCoerce $ pure $ LitE $ bytesPrimL (
+    let B.PS ptr off sz = bs
+    in  mkBytes ptr (fromIntegral off) (fromIntegral sz))
+
+-- | Embed a single file in your source code.
+--
+-- > import Data.String
+-- >
+-- > myFile :: IsString a => a
+-- > myFile = $$(embedStringFile "dirName/fileName")
+--
+-- @since $ver
+embedStringFile :: (IsString s, Quote m, Quasi m) => FilePath -> Code m s
+embedStringFile fp = (qAddDependentFile fp >> qRunIO (P.readFile fp)) `bindCode` strToExp
+
+-- | Embed a single existing string file in your source code
+-- out of list a list of paths supplied.
+--
+-- Warning: When a build is compiled with initial file(s) in the list missing, a
+-- recompile when one of those files exists might not trigger an embed of the
+-- first such file. You might try to fix this by doing a clean build or using
+-- GHC's -fforce-recomp flag.
+--
+-- @since $ver
+embedOneStringFileOf :: (IsString s, Quote m, Quasi m) => [FilePath] -> Code m s
+embedOneStringFileOf ps =
+  readExistingFile P.readFile ps `bindCode` strToExp
+
+-- | Lifts a stringy value into TH.
+strToExp :: (IsString s, Quote m) => String -> Code m s
+strToExp s = [|| fromString s ||]
+
+-- | Given a root folder, recursively get all files found in all subdirectories.
+-- Sorts by filepath.
+--
+-- Skips "hidden" files; specifically, those with a `.` at the front.
+fileList :: FilePath -> IO [(FilePath, B.ByteString)]
+fileList root = fileList' ""
+  where
+  fileList' :: FilePath -> IO [(FilePath, B.ByteString)]
+  fileList' top = do
+    allContents <- filter notHidden <$> getDirectoryContents (root </> top)
+    let -- relative paths from root and absolute paths from root for each file
+        relAndAbsPaths :: [(FilePath, FilePath)] = map ((top </>) &&& ((root </> top) </>)) allContents
+    files <- filterM (doesFileExist . snd) relAndAbsPaths >>=
+            mapM (bitraverse pure B.readFile)
+    dirs <- filterM (doesDirectoryExist . snd) relAndAbsPaths >>=
+            mapM (fileList' . fst)
+    return $ sortBy (comparing fst) $ concat $ files : dirs
+    where
+    notHidden :: FilePath -> Bool
+    notHidden ('.':_) = False
+    notHidden _ = True

--- a/Data/FileEmbed/Typed.hs
+++ b/Data/FileEmbed/Typed.hs
@@ -8,15 +8,15 @@
 {-# LANGUAGE TypeApplications #-}
 -- | This module uses template Haskell. Following is a simplified explanation of usage for those unfamiliar with calling Template Haskell functions.
 --
--- The function @embedFile@ in this modules embeds a file into the executable
--- that you can use it at runtime. A file is represented as a @ByteString@.
+-- The function 'embedFile' in this modules embeds a file into the executable
+-- that you can use it at runtime. A file is represented as a 'ByteString'.
 -- However, as you can see below, the type signature indicates a value of type
 -- @Code m ByteString@ will be returned. In order to convert this into a 
--- @ByteString@, you must use Typed Template Haskell syntax, e.g.:
+-- 'ByteString', you must use Typed Template Haskell syntax, e.g.:
 --
 -- > $$(embedFile "myfile.txt")
 --
--- This expression will have type @ByteString@. Be certain to enable the
+-- This expression will have type 'ByteString'. Be certain to enable the
 -- TemplateHaskell language extension, usually by adding the following to the
 -- top of your module:
 --

--- a/Data/FileEmbed/Typed.hs
+++ b/Data/FileEmbed/Typed.hs
@@ -23,6 +23,9 @@
 -- > {-# LANGUAGE TemplateHaskell #-}
 --
 -- Note that this module is the typed variant of @Data.FileEmbed@.
+-- As a result, you'll have to use 'bindCode' to use 'Data.FileEmbed.RelativePath'
+-- with the functions in this module, and as such it is re-exported for your
+-- convenience.
 module Data.FileEmbed.Typed
     ( -- * Embed at compile time
       embedFile
@@ -34,6 +37,8 @@ module Data.FileEmbed.Typed
       -- * Embed as a IsString
     , embedStringFile
     , embedOneStringFileOf
+      -- * Re-exports
+    , bindCode
     ) where
 
 import Language.Haskell.TH.Syntax

--- a/Data/FileEmbed/Typed.hs
+++ b/Data/FileEmbed/Typed.hs
@@ -39,6 +39,9 @@ module Data.FileEmbed.Typed
     , embedOneStringFileOf
       -- * Re-exports
     , bindCode
+      -- * Internals
+    , bsToExp
+    , strToExp
     ) where
 
 import Language.Haskell.TH.Syntax
@@ -172,6 +175,7 @@ convertList :: (Quote m) => [Code m a] -> Code m [a]
 convertList =
   foldr (\a z -> [|| $$a : $$z ||]) [|| [] ||]
 
+{-# WARNING in "x-file-embed-internals" bsToExp "This function is meant for internal `file-embed` use" #-}
 -- | Embed a bytestring into a static string.
 bsToExp :: Quote m => B.ByteString -> Code m B.ByteString
 bsToExp bs =
@@ -207,6 +211,7 @@ embedOneStringFileOf :: (IsString s, Quote m, Quasi m) => [FilePath] -> Code m s
 embedOneStringFileOf ps =
   readExistingFile P.readFile ps `bindCode` strToExp
 
+{-# WARNING in "x-file-embed-internals" strToExp "This function is meant for internal `file-embed` use" #-}
 -- | Lifts a stringy value into TH.
 strToExp :: (IsString s, Quote m) => String -> Code m s
 strToExp s = [|| fromString s ||]

--- a/Data/FileEmbed/Typed.hs
+++ b/Data/FileEmbed/Typed.hs
@@ -151,7 +151,7 @@ readExistingFile readFile' xs = do
 -- @since 0.1.0.0
 embedDir :: (Quasi m, Quote m) => FilePath -> Code m [(FilePath, B.ByteString)]
 embedDir fp = do
-  qRunIO (fileList fp) `bindCode` (convertList . fmap (pairToExp fp))
+  qRunIO (getDir fp) `bindCode` (convertList . fmap (pairToExp fp))
   where
   pairToExp :: forall m . (Quote m, Quasi m) => FilePath -> (FilePath, B.ByteString) -> Code m (FilePath, B.ByteString)
   pairToExp root (path, bs) = do
@@ -165,7 +165,7 @@ embedDir fp = do
 -- @since 0.1.0.0
 embedDirListing :: (Quote m, Quasi m) => FilePath -> Code m [FilePath]
 embedDirListing fp = do
-  qRunIO (fileList fp) `bindCode` (convertList . fmap (strToExp . fst))
+  qRunIO (getDir fp) `bindCode` (convertList . fmap (strToExp . fst))
 
 -- | Utility to turn a list of Codes into a Code of a list.
 convertList :: (Quote m) => [Code m a] -> Code m [a]
@@ -210,25 +210,3 @@ embedOneStringFileOf ps =
 -- | Lifts a stringy value into TH.
 strToExp :: (IsString s, Quote m) => String -> Code m s
 strToExp s = [|| fromString s ||]
-
--- | Given a root folder, recursively get all files found in all subdirectories.
--- Sorts by filepath.
---
--- Skips "hidden" files; specifically, those with a `.` at the front.
-fileList :: FilePath -> IO [(FilePath, B.ByteString)]
-fileList root = fileList' ""
-  where
-  fileList' :: FilePath -> IO [(FilePath, B.ByteString)]
-  fileList' top = do
-    allContents <- filter notHidden <$> getDirectoryContents (root </> top)
-    let -- relative paths from root and absolute paths from root for each file
-        relAndAbsPaths :: [(FilePath, FilePath)] = map ((top </>) &&& ((root </> top) </>)) allContents
-    files <- filterM (doesFileExist . snd) relAndAbsPaths >>=
-            mapM (bitraverse pure B.readFile)
-    dirs <- filterM (doesDirectoryExist . snd) relAndAbsPaths >>=
-            mapM (fileList' . fst)
-    return $ sortBy (comparing fst) $ concat $ files : dirs
-    where
-    notHidden :: FilePath -> Bool
-    notHidden ('.':_) = False
-    notHidden _ = True

--- a/Data/FileEmbed/Typed.hs
+++ b/Data/FileEmbed/Typed.hs
@@ -48,26 +48,20 @@ import Language.Haskell.TH.Syntax
     ( Quasi(..), Quote, Code, unsafeCodeCoerce, bindCode, Exp (LitE), bindCode_,
     )
 import Language.Haskell.TH ( mkBytes, bytesPrimL )
-import qualified Data.ByteString.Internal as B
-import System.Directory (doesDirectoryExist, doesFileExist,
-                         getDirectoryContents)
+import System.Directory (doesFileExist)
 import Control.Exception (tryJust)
 import Control.Monad (filterM, guard)
 import qualified Data.ByteString as B
+import qualified Data.ByteString.Internal as B
 import qualified Data.ByteString.Char8 as B8
-import Control.Arrow ((&&&))
 import Data.ByteString.Unsafe (unsafePackAddressLen)
 import System.IO.Error (isDoesNotExistError)
 import System.IO.Unsafe (unsafePerformIO)
-import System.FilePath ((</>))
 import Data.String (fromString, IsString)
 import Prelude as P
-import Data.List (sortBy)
-import Data.Ord (comparing)
 import Data.Functor (($>))
 import GHC.Exts (Addr#)
-import Data.Bitraversable (bitraverse)
-import Data.FileEmbed.RelativePath (makeRelativeToProject)
+import Data.FileEmbed.RelativePath (makeRelativeToProject, getDir)
 
 -- | Embed a single file in your source code.
 --

--- a/file-embed.cabal
+++ b/file-embed.cabal
@@ -1,5 +1,5 @@
 name:            file-embed
-version:         0.0.16.0
+version:         0.1.0.0
 license:         BSD2
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/file-embed.cabal
+++ b/file-embed.cabal
@@ -22,7 +22,7 @@ library
     build-depends:   base               >= 4.9.1   && < 5
                    , bytestring         >= 0.9.1.4
                    , directory          >= 1.0.0.3
-                   , template-haskell
+                   , template-haskell   >= 2.17.0.0
                    , filepath
     exposed-modules:
           Data.FileEmbed

--- a/file-embed.cabal
+++ b/file-embed.cabal
@@ -24,7 +24,11 @@ library
                    , directory          >= 1.0.0.3
                    , template-haskell
                    , filepath
-    exposed-modules: Data.FileEmbed
+    exposed-modules:
+          Data.FileEmbed
+        , Data.FileEmbed.Injection
+        , Data.FileEmbed.RelativePath
+        , Data.FileEmbed.Typed
     ghc-options:     -Wall
 
 test-suite test

--- a/file-embed.cabal
+++ b/file-embed.cabal
@@ -19,7 +19,7 @@ extra-source-files: test/main.hs, test/sample/foo, test/sample/bar/baz,
 
 library
     default-language: Haskell2010
-    build-depends:   base               >= 4.9.1   && < 5
+    build-depends:   base               >= 4.19.0.0   && < 5
                    , bytestring         >= 0.9.1.4
                    , directory          >= 1.0.0.3
                    , template-haskell   >= 2.17.0.0
@@ -29,7 +29,7 @@ library
         , Data.FileEmbed.Injection
         , Data.FileEmbed.RelativePath
         , Data.FileEmbed.Typed
-    ghc-options:     -Wall
+    ghc-options:     -Wall -Wno-x-file-embed-internals
 
 test-suite test
     default-language: Haskell2010


### PR DESCRIPTION
In this PR I split Data.FileEmbed into three modules: `Typed`, `RelativePath`, and `Injection`. The intent is that `RelativePath` contains `makeRelativeToProject` and `makeRelativeToLocationPredicate`, `Injection` contains all the functions to do with injecting data, and `Typed` contains typed template haskell function variants of the original `Data.FileEmbed` module. These are all then exported from `Data.FileEmbed`, and in the case of `Typed` turned into non-typed variants to maintain the existing API.

~~As part of this I also get rid of some unused, incredibly simple utility functions. These can be restored easily if need be.~~ These have been restored.

~~Were it not for the removed functions above, I believe this wouldn't be a breaking change - the API is maintained. Increasing the lower bounds means that older projects won't even try and obtain this version, meaning that we're free to use modern template-haskell.~~

To add the relevant warnings for internals functions, the minimum GHC we're permitted is 9.8